### PR TITLE
Fixed the default value of `category` argument

### DIFF
--- a/Proxy_List_Scrapper/__init__.py
+++ b/Proxy_List_Scrapper/__init__.py
@@ -67,7 +67,7 @@ class Scrapper:
     Scrapper class is use to scrape the proxies from various websites.
     """
 
-    def __init__(self, category='ssl', print_err_trace=True):
+    def __init__(self, category='SSL', print_err_trace=True):
         """
         Initialization of scrapper class
         :param category: Category of proxy to scrape.


### PR DESCRIPTION
The default argument should have been `SSL` instead of `ssl`. As per the values defined by `Categories` dictionary in the Scraper class.